### PR TITLE
Add support for connection by hostname

### DIFF
--- a/lib/em-socksify/socksify.rb
+++ b/lib/em-socksify/socksify.rb
@@ -36,9 +36,9 @@ module EventMachine
       begin
         # TODO: Implement address types for IPv6 and Domain
         # TODO: resolve domain through the proxy
-        send_data [1, Socket.gethostbyname(@host).last].pack('CA4n')
+        send_data [1, Socket.gethostbyname(@host).last].pack('CA4')
       rescue
-        send_data [3, @host.size, @host].pack('CCA4n')
+        send_data [3, @host.size, @host].pack('CCA*')
       end
 
       send_data [@port].pack('n')


### PR DESCRIPTION
Looking at socksify-ruby and em-socksify I found what was missing.

My em-http-request thingy doesn't work yet, but now I don't know where the error is.

If you want to check out the code that uses em-http-request it's here: https://github.com/meh/torb/blob/master/puppet/puppet.rb
