### PR TITLE
Add catchable error handling

### DIFF
--- a/lib/em-socksify/socks5.rb
+++ b/lib/em-socksify/socks5.rb
@@ -101,7 +101,7 @@ module EventMachine
             socks_unhook(ip)
           end
         rescue Exception => e
-          @socks_deferable.fail(e)
+          @socks_deferrable.fail(e)
         end
 
         def socks_methods

--- a/lib/em-socksify/socksify.rb
+++ b/lib/em-socksify/socksify.rb
@@ -12,10 +12,9 @@ module EventMachine
       socks_hook
       socks_send_handshake
 
-      @socks_deferable = DefaultDeferrable.new
-      @socks_deferable.callback(&blk) if blk
-      @socks_deferable.errback { |e| raise e }
-      @socks_deferable
+      @socks_deferrable = DefaultDeferrable.new
+      @socks_deferrable.callback(&blk) if blk
+      @socks_deferrable
     end
 
     def socks_hook
@@ -35,7 +34,7 @@ module EventMachine
         remove_method :receive_data
       end
 
-      @socks_deferable.succeed(ip)
+      @socks_deferrable.succeed(ip)
     end
 
     def socks_receive_data(data)


### PR DESCRIPTION
I was having some issues dealing with SOCKS errors, now errors will be handled by the passed block.

Now it works like this:

``` ruby
    socksify('google.ca', 80) do |e|
      if socks_error?
        # do something with the exception
      else
        send_data "GET / HTTP/1.1\r\nConnection:close\r\nHost: google.ca\r\n\r\n"
      end
    end 
```

You can also pass true as the last argument of `socksify` to force it to raise instead of passing the exception to the callback.

If you have any better idea to deal with this I'll be glad to implement it.

I also think we should add the chance to pass an Hash instead of `username, password, version, always_raise`, I will open a different pull request for that though.
