### PR TITLE
[BUGFIX] Permit connections to IPv4 addresses

### DIFF
--- a/lib/em-socksify/socks5.rb
+++ b/lib/em-socksify/socks5.rb
@@ -18,7 +18,7 @@ module EventMachine
         send_data [5, 1, 0].pack('CCC')
 
         if matches = @socks_target_host.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/)
-          send_data "\xF1\x00\x01" + matches.to_a[1 .. -1].map { |s| s.to_i }.pack('CCCC')
+          send_data "\x01" + matches.to_a[1 .. -1].map { |s| s.to_i }.pack('CCCC')
 
         elsif @socks_target_host =~ /^[:0-9a-f]+$/
           raise SOCKSError, 'TCP/IPv6 over SOCKS is not yet supported (inet_pton missing in Ruby & not supported by Tor)'


### PR DESCRIPTION
Remove "\xF1\x00" preceeding IP address. I'm certainly no expert in the SOCKS5 protocol but this is closer to what the socksify Gem does. Tested with OpenSSH and Tor.
