### PR TITLE
Add a simplified way to handle SOCKS connections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@ EM.run do
 end
 ```
 
+```ruby
+class Handler < EM::Connection
+  def connection_completed
+    send_data "GET / HTTP/1.1\r\nConnection:close\r\nHost: google.ca\r\n\r\n"
+  end
+
+  def receive_data(data)
+    p data
+  end
+end
+
+EM.run do
+  EventMachine.connect_through [SOCKS_HOST, SOCKS_PORT], 'google.ca', 80, Handler
+end
+```
+
 What's happening here? First, we open a raw TCP connection to the SOCKS proxy (after all, all data will flow through it). Then, we provide a Handler connection class, which includes "EM::Socksify". Once the TCP connection is established, EventMachine calls the **connection_completed** method in our handler. Here, we call socksify with the actual destination host & port (address that we actually want to get to), and the module does the rest.
 
 After you call socksify, the module temporarily intercepts your receive_data callbacks, negotiates the SOCKS connection (version, authentication, etc), and then once all is done, returns the control back to your code. Simple as that.

--- a/lib/em-socksify.rb
+++ b/lib/em-socksify.rb
@@ -3,3 +3,25 @@ require 'eventmachine'
 require 'em-socksify/socksify'
 require 'em-socksify/errors'
 require 'em-socksify/socks5'
+
+module EventMachine
+  def connect_through (proxy, server, port, handler, *args, &blk)
+    handler.instance_eval {
+      include EM::Socksify
+
+      connected = instance_method(:connection_completed) rescue nil
+
+      define_method :connection_completed do
+        socksify(server, port, *proxy[2 .. -1]).callback {
+          connected.bind(self).call if connected
+        }.errback {|e|
+          raise e
+        }
+      end
+    }
+
+    connect proxy[0], proxy[1], handler, *args, &blk
+  end
+
+  module_function :connect_through
+end


### PR DESCRIPTION
I added an helper module function to deal with socks connections, it should be the main way to use em-socksify unless advanced features are needed.

Any feedback on this?
