### PR TITLE
fix: catch CONNECTError exceptions too

### DIFF
--- a/lib/em-socksify/connect.rb
+++ b/lib/em-socksify/connect.rb
@@ -20,7 +20,7 @@ module EventMachine
         end
 
         connect_unhook
-      rescue => e
+      rescue Exception => e
         @connect_deferrable.fail e
       end
     end


### PR DESCRIPTION
Why does not you catch CONNECTError?
