### PR TITLE
add MIT license metadata to gemspec

### DIFF
--- a/em-socksify.gemspec
+++ b/em-socksify.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/igrigorik/em-socksify"
   s.summary     = "Transparent proxy support for any EventMachine protocol"
   s.description = s.summary
+  s.license     = "MIT"
 
   s.rubyforge_project = "em-socksify"
 


### PR DESCRIPTION
This pull request allows RubyGems.org and other tools (such as gem2rpm) to report a license for your gem.
