### PR TITLE
add full MIT license text

### DIFF
--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,0 +1,10 @@
+Copyright (c) 2014, Ilya Grigorik and Other Contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Hi Ilya,

Thank you very much for your work on em-socksify. @niteshnarayanlal is working on packaging this gem for Fedora (https://bugzilla.redhat.com/1063040), and the Fedora Packaging Guidelines suggest that we ask you to include a LICENSE file in the root of the project. By including a copy of the exact MIT license text, you will make the terms of the em-socksify license very clear.

Also, in the specific case of em-socksify's MIT license, all derivative copies of em-socksify are required to contain the disclaimer text within the MIT license (as described in the sentence "The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.") So in order to ease development and distribution of em-socksify, it makes sense to simply include this text in the upstream project.

More details about this can be found on Fedora's wiki, under the "License Text" section: https://fedoraproject.org/wiki/Packaging:LicensingGuidelines#License_Text

Would you mind adding this LICENSE file with the MIT license text to the git repo and the gem?
