### PR TITLE
use HTTPS for URL in gemspec

### DIFF
--- a/em-socksify.gemspec
+++ b/em-socksify.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Ilya Grigorik"]
   s.email       = ["ilya@igvita.com"]
-  s.homepage    = "http://github.com/igrigorik/em-socksify"
+  s.homepage    = "https://github.com/igrigorik/em-socksify"
   s.summary     = "Transparent proxy support for any EventMachine protocol"
   s.description = s.summary
 


### PR DESCRIPTION
This pull request updates the gemspec metadata to use HTTPS for the homepage URL.
