### PR TITLE
Stop overly eager rescue in `connect_parse_response`

### DIFF
--- a/lib/em-socksify/connect.rb
+++ b/lib/em-socksify/connect.rb
@@ -20,7 +20,7 @@ module EventMachine
         end
 
         connect_unhook
-      rescue Exception => e
+      rescue => e
         @connect_deferrable.fail e
       end
     end


### PR DESCRIPTION
Rescuing `Exception` is bad practice because it handles every possible exeption in Ruby, including those like NoMemoryError and SyntaxError. Also, this method may raise `CONNECTError`, which is a direct subclass of `Exception`, and it doesn't make sense to handle an exception that we just raised in the same method.

Reverts #13 because it started causing problems for me. I have em-http code that makes requests through a proxy server. When the proxy authentication fails due to incorrect password, the proxy server returns a 407 "Proxy Authentication Required", but inside em-socksify this exception get swallowed and turned into RuntimeError with message "connection closed by server". The proxy server didn't close the connection prematurely: it properly responsed with 407.