### PR TITLE
Remove space between method call and parentheses.

### DIFF
--- a/lib/em-socksify/errors.rb
+++ b/lib/em-socksify/errors.rb
@@ -2,7 +2,7 @@ module EventMachine
   module Socksify
 
     class SOCKSError < Exception
-      def self.define (message)
+      def self.define(message)
         Class.new(self) do
           def initialize
             super(message)


### PR DESCRIPTION
Avoid `warning: parentheses after method name is interpreted as an argument list, not a decomposed argument`