### PR TITLE
Add base64 as dependency

### DIFF
--- a/em-socksify.gemspec
+++ b/em-socksify.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "em-socksify"
 
+  s.add_dependency "base64"
   s.add_dependency "eventmachine", ">= 1.0.0.beta.4"
   s.add_development_dependency "rspec"
   s.add_development_dependency "rake"


### PR DESCRIPTION
Using em-socksify with Ruby 3.3.3 will emit the following deprecation warning:
> .../em-socksify/lib/em-socksify.rb:2: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec.
